### PR TITLE
Switch to using opensuse mirrors, update Debian/Ubuntu releases, update to 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,14 @@ all: # nothing to build
 
 install:
 	mkdir -p ${DESTDIR}/usr/share/cvmfs-contrib-release
-	for OSVER in Ubuntu_20.04 Ubuntu_22.04 Ubuntu_24.04 Debian_10 Debian_11 Debian_12; do \
+	for OSVER in Ubuntu_22.04 Ubuntu_24.04 Ubuntu_26.04 Debian_11 Debian_12 Debian_13; do \
 	    case $$OSVER in \
 		Ubuntu*) REPO="x$$OSVER";; \
 		*) REPO="$$OSVER";; \
 	    esac; \
 	    (echo "# Do not edit.  Remove symlink and make a copy in /etc/apt/sources.list.d"; \
-	    echo "# browsable alternate at http://download.opensuse.org/repositories/home:/cvmfs:/contrib/$$REPO ./"; \
-	    echo "deb http://downloadcontent.opensuse.org/repositories/home:/cvmfs:/contrib/$$REPO ./"; \
-	    echo "# browsable alternate at http://download.opensuse.org/repositories/home:/cvmfs:/contrib-testing/$$REPO ./"; \
-	    echo "# deb http://downloadcontent.opensuse.org/repositories/home:/cvmfs:/contrib-testing/$$REPO ./"; \
+	    echo "deb http://download.opensuse.org/repositories/home:/cvmfs:/contrib/$$REPO ./"; \
+	    echo "# deb http://download.opensuse.org/repositories/home:/cvmfs:/contrib-testing/$$REPO ./"; \
 	    ) >${DESTDIR}/usr/share/cvmfs-contrib-release/cvmfs-contrib-$$OSVER.list; \
 	done
 	mkdir -p ${DESTDIR}/etc/apt/trusted.gpg.d

--- a/debian/cvmfs-contrib-release.dsc
+++ b/debian/cvmfs-contrib-release.dsc
@@ -1,7 +1,7 @@
 # created by obsupdate.sh, do not edit by hand
-Debtransform-Tar: cvmfs-contrib-release-1.21.tar.gz
+Debtransform-Tar: cvmfs-contrib-release-1.22.tar.gz
 Format: 1.0
-Version: 1.21.1
+Version: 1.22.1
 Binary: cvmfs-contrib-release
 Source: cvmfs-contrib-release
 Maintainer: Dave Dykstra <dwd@fnal.gov>

--- a/rpm/cvmfs-contrib-release.spec
+++ b/rpm/cvmfs-contrib-release.spec
@@ -1,5 +1,5 @@
 Name:           cvmfs-contrib-release
-Version:        1.21
+Version:        1.22
 # The release_prefix macro is used in the OBS prjconf, don't change its name
 %define release_prefix 1
 # %%{?dist} is left off intentionally; this rpm works on multiple OS releases
@@ -92,6 +92,10 @@ if [ ! -e $REPO ]; then
 fi
 
 %changelog
+* Mon Jun 15 2026 Dave Dykstra <dwd@fnal.gov> - 1.22-1
+- Switch to using opensuse mirrors intead of the master download server.
+- Add Debian 13, Ubuntu 26.04 and remove Debian 10, Ubuntu 20.04 support.
+
 * Tue Sep  2 2025 Dave Dykstra <dwd@fnal.gov> - 1.21-1
 - Add support for AlmaLinux 10 and Fedora 41 and 42.
 

--- a/rpm/cvmfs-contrib.repo.in
+++ b/rpm/cvmfs-contrib.repo.in
@@ -4,8 +4,7 @@
 [cvmfs-contrib]
 name=CernVM Filesystem Contributions
 type=rpm-md
-# browsable alternate at http://download.opensuse.org/repositories/home:/cvmfs:/contrib/{distro}_{osnum}/
-baseurl=http://downloadcontent.opensuse.org/repositories/home:/cvmfs:/contrib/{distro}_{osnum}/
+baseurl=http://download.opensuse.org/repositories/home:/cvmfs:/contrib/{distro}_{osnum}/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CVMFS-CONTRIB
 enabled=1
@@ -13,8 +12,7 @@ enabled=1
 [cvmfs-contrib-testing]
 name=CernVM Filesystem Contributions testing
 type=rpm-md
-# browsable alternate at http://download.opensuse.org/repositories/home:/cvmfs:/contrib-testing/{distro}_{osnum}/
-baseurl=http://downloadcontent.opensuse.org/repositories/home:/cvmfs:/contrib-testing/{distro}_{osnum}/
+baseurl=http://download.opensuse.org/repositories/home:/cvmfs:/contrib-testing/{distro}_{osnum}/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CVMFS-CONTRIB
 enabled=0
@@ -22,8 +20,7 @@ enabled=0
 [cvmfs-contrib-egi]
 name=CernVM Filesystem Contributions for EGI
 type=rpm-md
-# browsable alternate at http://download.opensuse.org/repositories/home:/cvmfs:/contrib-egi/{distro}_{osnum}/
-baseurl=http://downloadcontent.opensuse.org/repositories/home:/cvmfs:/contrib-egi/{distro}_{osnum}/
+baseurl=http://download.opensuse.org/repositories/home:/cvmfs:/contrib-egi/{distro}_{osnum}/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CVMFS-CONTRIB
 enabled=0
@@ -31,8 +28,7 @@ enabled=0
 [cvmfs-contrib-egi-testing]
 name=CernVM Filesystem Contributions for EGI testing
 type=rpm-md
-# browsable alternate at http://download.opensuse.org/repositories/home:/cvmfs:/contrib-egi-testing/{distro}_{osnum}/
-baseurl=http://downloadcontent.opensuse.org/repositories/home:/cvmfs:/contrib-egi-testing/{distro}_{osnum}/
+baseurl=http://download.opensuse.org/repositories/home:/cvmfs:/contrib-egi-testing/{distro}_{osnum}/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CVMFS-CONTRIB
 enabled=0


### PR DESCRIPTION
I found out it is discouraged to use downloadcontent.opensuse.org which is the base service; only download.opensuse.org which are mirrors are supposed to be used.